### PR TITLE
fixed memory leak in strophe_send()

### DIFF
--- a/strophe.c
+++ b/strophe.c
@@ -32,6 +32,8 @@ static void strophe_send(xmpp_ctx_t *ctx, xmpp_conn_t *conn, char *to, char *msg
         xmpp_stanza_add_child(message, body);
 
         xmpp_send(conn, message);
+        xmpp_stanza_release(text);
+        xmpp_stanza_release(body);
         xmpp_stanza_release(message);
 }
 


### PR DESCRIPTION
`xmpp_stanza_add_child()` clones the child stanza (in fact, just increases reference count). Therefore, all child stanzas must be released too.
